### PR TITLE
fix typo in api go mod path

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,4 +1,4 @@
-module github.com/mellanox/maintenance-operator/api
+module github.com/Mellanox/maintenance-operator/api
 
 go 1.22.0
 


### PR DESCRIPTION
fix typo in api go mod path