### PR TITLE
fix minor race issue when waiting for condition

### DIFF
--- a/internal/controller/nodemaintenancescheduler_controller.go
+++ b/internal/controller/nodemaintenancescheduler_controller.go
@@ -209,7 +209,8 @@ func (r *NodeMaintenanceSchedulerReconciler) Reconcile(ctx context.Context, req 
 					r.Log.Error(innerErr, "failed to get NodeMaintenance object while waiting for condition update. retrying", "name", nm.Name, "namespace", nm.Namespace)
 					return false, nil
 				}
-				if k8sutils.GetReadyConditionReason(updatedNm) == maintenancev1.ConditionReasonScheduled {
+				if k8sutils.IsUnderMaintenance(updatedNm) {
+					// nodemaintenance transitioned from pending to one of the under maintenance states.
 					return true, nil
 				}
 				return false, nil


### PR DESCRIPTION
scheduler sets nodemaintenance to scheduled state in condition then waits for it to be updated in cache.

between polling intervals a nodemaintenance may already be transitioned to a more advance state e.g draining or ready.

instead, check if node is under maintenance to match on any other state than uninitialized or pending.