### PR TITLE
fix: 'timeExpire'  int32 overflow in waitForPodCompletion

### DIFF
--- a/internal/podcompletion/podcompletion.go
+++ b/internal/podcompletion/podcompletion.go
@@ -90,7 +90,7 @@ func (p *podCompletionHandler) HandlePodCompletion(ctx context.Context, reqLog l
 	// check expire time
 	if nm.Spec.WaitForPodCompletion.TimeoutSecond > 0 {
 		timeNow := time.Now()
-		timeExpire := startTime.Add(time.Duration(nm.Spec.WaitForPodCompletion.TimeoutSecond * int32(time.Second)))
+		timeExpire := startTime.Add(time.Duration(nm.Spec.WaitForPodCompletion.TimeoutSecond) * time.Second)
 		if timeNow.After(timeExpire) {
 			reqLog.Error(nil, "HandlePodCompletion timeout reached")
 			return nil, ErrPodCompletionTimeout


### PR DESCRIPTION
We were getting unexpected timeouts while trying to set `nodeMaintenance.spec.waitForPodCompletion.timeoutSeconds`
`time.Second` is of type `time.Duration `(int64) so 1 Second (in nanoseconds) will overflow