### PR TITLE
chore: update default node maintenance time

### DIFF
--- a/api/v1alpha1/maintenanceoperatorconfig_types.go
+++ b/api/v1alpha1/maintenanceoperatorconfig_types.go
@@ -52,8 +52,8 @@ type MaintenanceOperatorConfigSpec struct {
 	// MaxNodeMaintenanceTimeSeconds is the time from when a NodeMaintenance is marked as ready (phase: Ready)
 	// until the NodeMaintenance is considered stale and removed by the operator.
 	// should be less than idle time for any autoscaler that is running.
-	// default to 30m (1600 seconds)
-	// +kubebuilder:default=1600
+	// default to 60m (3600 seconds)
+	// +kubebuilder:default=3600
 	// +kubebuilder:validation:Minimum:=0
 	MaxNodeMaintenanceTimeSeconds int32 `json:"maxNodeMaintenanceTimeSeconds,omitempty"`
 }

--- a/config/crd/bases/maintenance.nvidia.com_maintenanceoperatorconfigs.yaml
+++ b/config/crd/bases/maintenance.nvidia.com_maintenanceoperatorconfigs.yaml
@@ -50,12 +50,12 @@ spec:
                 - error
                 type: string
               maxNodeMaintenanceTimeSeconds:
-                default: 1600
+                default: 3600
                 description: |-
                   MaxNodeMaintenanceTimeSeconds is the time from when a NodeMaintenance is marked as ready (phase: Ready)
                   until the NodeMaintenance is considered stale and removed by the operator.
                   should be less than idle time for any autoscaler that is running.
-                  default to 30m (1600 seconds)
+                  default to 60m (3600 seconds)
                 format: int32
                 minimum: 0
                 type: integer

--- a/deployment/maintenance-operator-chart/crds/maintenance.nvidia.com_maintenanceoperatorconfigs.yaml
+++ b/deployment/maintenance-operator-chart/crds/maintenance.nvidia.com_maintenanceoperatorconfigs.yaml
@@ -50,12 +50,12 @@ spec:
                 - error
                 type: string
               maxNodeMaintenanceTimeSeconds:
-                default: 1600
+                default: 3600
                 description: |-
                   MaxNodeMaintenanceTimeSeconds is the time from when a NodeMaintenance is marked as ready (phase: Ready)
                   until the NodeMaintenance is considered stale and removed by the operator.
                   should be less than idle time for any autoscaler that is running.
-                  default to 30m (1600 seconds)
+                  default to 60m (3600 seconds)
                 format: int32
                 minimum: 0
                 type: integer

--- a/internal/controller/garbage_collector_controller.go
+++ b/internal/controller/garbage_collector_controller.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	defaultMaxNodeMaintenanceTime         = 1600 * time.Second
+	defaultMaxNodeMaintenanceTime         = 3600 * time.Second
 	defaultGarbageCollectionReconcileTime = 5 * time.Minute
 	garbageCollectionReconcileTime        = defaultGarbageCollectionReconcileTime
 )
@@ -72,7 +72,7 @@ func (gco *GarbageCollectorOptions) Load() {
 	gco.maxNodeMaintenanceTime = gco.pendingMaxNodeMaintenanceTime
 }
 
-// MaxNodeMaintenanceTime returns the last loaded MaxUnavailable option
+// MaxNodeMaintenanceTime returns the last loaded MaxNodeMaintenanceTime option
 func (gco *GarbageCollectorOptions) MaxNodeMaintenanceTime() time.Duration {
 	return gco.maxNodeMaintenanceTime
 }


### PR DESCRIPTION
update default from 24min to 60min to allow a
better out-of-box margin for performing node maintenance operations on a node.