### PR TITLE
Revert "fix: update deployment template 'imagePullSecrets' 

### DIFF
--- a/deployment/maintenance-operator-chart/templates/deployment.yaml
+++ b/deployment/maintenance-operator-chart/templates/deployment.yaml
@@ -27,12 +27,7 @@ spec:
       tolerations: {{- toYaml .Values.operator.tolerations | nindent 8 }}
       nodeSelector: {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
       affinity: {{- toYaml .Values.operator.affinity | nindent 8 }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range .Values.imagePullSecrets }}
-        - name: {{ . }}
-        {{- end }}
-      {{- end }}
+      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "maintenance-operator.fullname" . }}-controller-manager


### PR DESCRIPTION
Since we're going to align `imagePullSecrets` under all network-operator dependencies in `values.yaml`, to be using the following:
```
imagePullSecrets:
  - "name: pull-secret-name"
```
instead of:
```
imagePullSecrets:
  - pull-secret-name
```