### PR TITLE
chore: bump nvidia/distroless/go from v3.1.9 to v3.1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM nvcr.io/nvidia/distroless/go:v3.1.9
+FROM nvcr.io/nvidia/distroless/go:v3.1.10
 WORKDIR /
 COPY --from=builder /workspace/build/manager .
 USER 65532:65532


### PR DESCRIPTION
Bumps nvidia/distroless/go from v3.1.9 to v3.1.10.

---
updated-dependencies:
- dependency-name: nvidia/distroless/go dependency-version: v3.1.10 dependency-type: direct:production ...