### PR TITLE
fix: align OLM/Kustomize deployment with Helm chart

### DIFF
--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -2611,6 +2611,37 @@ THE SOFTWARE.
    limitations under the License.
 
 ---
+## spdy
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
 ## term
 
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,19 +1,3 @@
-# Copyright 2025 NVIDIA CORPORATION & AFFILIATES
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 FROM scratch
 
 # Core bundle labels.

--- a/bundle/manifests/nvidia-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nvidia-maintenance-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-13T12:33:06Z"
+    createdAt: "2026-05-12T13:59:16Z"
     description: Node maintenance in K8s cluster in a coordinated manner
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -235,8 +235,22 @@ spec:
                 annotations:
                   kubectl.kubernetes.io/default-container: manager
                 labels:
+                  app.kubernetes.io/component: maintenance-operator-controller-manager
                   control-plane: controller-manager
               spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/master
+                              operator: Exists
+                        weight: 1
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/control-plane
+                              operator: Exists
+                        weight: 1
                 containers:
                   - args:
                       - --leader-elect
@@ -283,12 +297,20 @@ spec:
                       - mountPath: /tmp/k8s-webhook-server/serving-certs
                         name: cert
                         readOnly: true
+                priorityClassName: system-cluster-critical
                 securityContext:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
                 serviceAccountName: maintenance-operator-controller-manager
                 terminationGracePeriodSeconds: 10
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
                 volumes:
                   - name: cert
                     secret:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,28 +35,29 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/component: maintenance-operator-controller-manager
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
-      # affinity:
-      #   nodeAffinity:
-      #     requiredDuringSchedulingIgnoredDuringExecution:
-      #       nodeSelectorTerms:
-      #         - matchExpressions:
-      #           - key: kubernetes.io/arch
-      #             operator: In
-      #             values:
-      #               - amd64
-      #               - arm64
-      #               - ppc64le
-      #               - s390x
-      #           - key: kubernetes.io/os
-      #             operator: In
-      #             values:
-      #               - linux
       priorityClassName: system-cluster-critical
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "node-role.kubernetes.io/master"
+                    operator: Exists
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "node-role.kubernetes.io/control-plane"
+                    operator: Exists
       securityContext:
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
Add missing pod template label app.kubernetes.io/component= maintenance-operator-controller-manager to config/manager/manager.yaml and the bundle CSV. The label was only set on the Deployment metadata, not on the pod template, so the implicit drain exclusion selector had no effect — causing the operator to evict its own pod on single-node clusters (introduced in 84a04f5).

Also add tolerations for node-role.kubernetes.io/master and node-role.kubernetes.io/control-plane NoSchedule taints, and a soft node affinity preference for control-plane nodes, bringing the Kustomize/OLM path to parity with the Helm chart.