### PR TITLE
ci: remove netop CI branch trigger

### DIFF
--- a/.github/workflows/netop-ci.yaml
+++ b/.github/workflows/netop-ci.yaml
@@ -15,8 +15,6 @@ name: Fork Release CI
 
 on:
   push:
-    branches:
-      - network-operator-*
     tags:
       - network-operator-*
 


### PR DESCRIPTION
## Summary
- remove the `network-operator-*` branch trigger from the reusable fork-ci workflow on this release branch
- keep `network-operator-*` tag triggers for release builds

## Verification
- YAML parse check for `.github/workflows/netop-ci.*`
- `git diff --check`