### PR TITLE
feat(chart): allow signing the webhook certificate with your own issuer

### DIFF
--- a/deployment/maintenance-operator-chart/README.md
+++ b/deployment/maintenance-operator-chart/README.md
@@ -11,22 +11,22 @@ Maintenance Operator Helm Chart
 | imagePullSecrets | list | `[]` | image pull secrets for the operator |
 | metricsService | object | `{"ports":[{"name":"https","port":8443,"protocol":"TCP","targetPort":"https"}],"type":"ClusterIP"}` | metrics service configurations |
 | operator.admissionController.certificates.certManager.enable | bool | `true` | use cert-manager for certificates |
-| operator.admissionController.certificates.certManager.generateSelfSigned | bool | `true` | generate self-signed certificiates with cert-manager |
+| operator.admissionController.certificates.certManager.issuerRef | object | `{}` | reference to an existing cert-manager issuer that signs the certificate. When `name` is empty a self-signed issuer is created and used. Set this to chain the admission controller certificate to a certificate authority you own. `kind` defaults to `Issuer` and `group` to `cert-manager.io` |
 | operator.admissionController.certificates.custom.enable | bool | `false` | enable custom certificates using secrets |
 | operator.admissionController.certificates.secretNames.operator | string | `"operator-webhook-cert"` | secret name containing certificates for the operator admission controller |
 | operator.admissionController.enable | bool | `true` | enable admission controller of the operator |
 | operator.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/master","operator":"Exists"}]},"weight":1},{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]},"weight":1}]}}` | node affinity for the operator |
 | operator.image.imagePullPolicy | string | `nil` | image pull policy for the operator image |
-| operator.image.repository | string | `"ghcr.io/mellanox"` | repository to use for the operator image |
 | operator.image.name | string | `"maintenance-operator"` | image name to use for the operator image |
+| operator.image.repository | string | `"ghcr.io/mellanox"` | repository to use for the operator image |
 | operator.image.tag | string | `nil` | image tag to use for the operator image |
 | operator.nodeSelector | object | `{}` | node selector for the operator |
 | operator.replicas | int | `1` | operator deployment number of repplicas |
 | operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | specify resource requests and limits for the operator |
 | operator.serviceAccount.annotations | object | `{}` | set annotations for the operator service account |
 | operator.tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]` | toleration for the operator |
-| operatorConfig | object | `{"logLevel":"info","maxNodeMaintenanceTimeSeconds":null,"maxParallelOperations":null,"maxUnavailable":null}` | operator configuration values. fields here correspond to fields in MaintenanceOperatorConfig CR |
-| operatorConfig.deploy | bool | `false` | deploy operatorConfig custom resource |
+| operatorConfig | object | `{"deploy":false,"logLevel":"info","maxNodeMaintenanceTimeSeconds":null,"maxParallelOperations":null,"maxUnavailable":null}` | operator configuration values. fields here correspond to fields in MaintenanceOperatorConfig CR |
+| operatorConfig.deploy | bool | `false` | deploy operatorConfig CR with the below values |
 | operatorConfig.logLevel | string | `"info"` | log level configuration |
 | operatorConfig.maxNodeMaintenanceTimeSeconds | string | `nil` | max time for node maintenance |
 | operatorConfig.maxParallelOperations | string | `nil` | max number of parallel operations |

--- a/deployment/maintenance-operator-chart/templates/certificates.yaml
+++ b/deployment/maintenance-operator-chart/templates/certificates.yaml
@@ -1,16 +1,28 @@
-{{- if and .Values.operator.admissionController.enable }}
-{{- if and .Values.operator.admissionController.certificates.certManager.enable
-  .Values.operator.admissionController.certificates.certManager.generateSelfSigned }}
+{{- if .Values.operator.admissionController.enable }}
+{{- $certificates := .Values.operator.admissionController.certificates }}
+{{- $certManager := $certificates.certManager }}
+{{- $issuerRef := $certManager.issuerRef | default dict }}
+{{- $issuerName := printf "%s-selfsigned-issuer" (include "maintenance-operator.fullname" .) }}
+{{- $issuerKind := "Issuer" }}
+{{- $issuerGroup := "cert-manager.io" }}
+{{- if $issuerRef.name }}
+{{- $issuerName = $issuerRef.name }}
+{{- $issuerKind = $issuerRef.kind | default $issuerKind }}
+{{- $issuerGroup = $issuerRef.group | default $issuerGroup }}
+{{- end }}
+{{- if $certManager.enable }}
+{{- if not $issuerRef.name }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "maintenance-operator.fullname" . }}-selfsigned-issuer
+  name: {{ $issuerName | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "maintenance-operator.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
 ---
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -25,19 +37,20 @@ spec:
   - '{{ include "maintenance-operator.fullname" . }}-webhook-service.{{ .Release.Namespace
     }}.svc.{{ .Values.kubernetesClusterDomain | default "cluster.local" }}'
   issuerRef:
-    kind: Issuer
-    name: '{{ include "maintenance-operator.fullname" . }}-selfsigned-issuer'
-  secretName: {{ .Values.operator.admissionController.certificates.secretNames.operator }}
-{{- else if and (not .Values.operator.admissionController.certManager.enable) .Values.operator.admissionController.custom.enable }}
+    kind: {{ $issuerKind | quote }}
+    name: {{ $issuerName | quote }}
+    group: {{ $issuerGroup | quote }}
+  secretName: {{ $certificates.secretNames.operator }}
+{{- else if $certificates.custom.enable }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.operator.admissionController.certificates.secretNames.operator }}
+  name: {{ $certificates.secretNames.operator }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  ca.crt: {{ .Values.operator.admissionController.certificates.custom.operator.caCrt | b64enc | b64enc | quote }}
-  tls.crt: {{ .Values.operator.admissionController.certificates.custom.operator.tlsCrt | b64enc | quote }}
-  tls.key: {{ .Values.operator.admissionController.certificates.custom.operator.tlsKey | b64enc | quote }}
+  ca.crt: {{ $certificates.custom.operator.caCrt | b64enc | quote }}
+  tls.crt: {{ $certificates.custom.operator.tlsCrt | b64enc | quote }}
+  tls.key: {{ $certificates.custom.operator.tlsKey | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/deployment/maintenance-operator-chart/templates/webhook.yaml
+++ b/deployment/maintenance-operator-chart/templates/webhook.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.operator.admissionController.enable }}
+{{- $certificates := .Values.operator.admissionController.certificates }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,14 +22,19 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "maintenance-operator.fullname" . }}-validating-webhook-configuration
+  {{- if $certificates.certManager.enable }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "maintenance-operator.fullname" . }}-serving-cert
+  {{- end }}
   labels:
   {{- include "maintenance-operator.labels" . | nindent 4 }}
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
+    {{- if and (not $certificates.certManager.enable) $certificates.custom.enable }}
+    caBundle: {{ $certificates.custom.operator.caCrt | b64enc | quote }}
+    {{- end }}
     service:
       name: '{{ include "maintenance-operator.fullname" . }}-webhook-service'
       namespace: {{ .Release.Namespace }}

--- a/deployment/maintenance-operator-chart/values.yaml
+++ b/deployment/maintenance-operator-chart/values.yaml
@@ -55,8 +55,14 @@ operator:
       certManager:
         # -- use cert-manager for certificates
         enable: true
-        # -- generate self-signed certificiates with cert-manager
-        generateSelfSigned: true
+        # -- reference to an existing cert-manager issuer that signs the certificate. When `name` is
+        # empty a self-signed issuer is created and used. Set this to chain the admission controller
+        # certificate to a certificate authority you own. `kind` defaults to `Issuer` and `group` to
+        # `cert-manager.io`
+        issuerRef: {}
+        #   name: my-issuer
+        #   kind: ClusterIssuer
+        #   group: cert-manager.io
       custom:
         # -- enable custom certificates using secrets
         enable: false


### PR DESCRIPTION
Add certificates.certManager.issuerRef to point the admission controller
certificate at an existing cert-manager issuer. A self-signed issuer is
created only when no issuer is given.

It replaces generateSelfSigned, which never rendered: setting it to false
fell into the custom certificate branch, whose condition read the wrong
value paths. Repair that branch, the double base64 encoding of ca.crt and
the CA injection of the webhook, which had no source in custom mode.